### PR TITLE
Announce k8s cluster update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,9 +16,9 @@ window, as follow
 ```
 ---
 title: Event Title
-date: YYYY-MM-DD HH:MM:SS
+date: YYYY-MM-DD HH:MM:SS UTC
 resolved: true
-resolvedWhen: YYYY-MM-DD HH:MM:SS
+resolvedWhen: YYYY-MM-DD HH:MM:SS UTC
 # Possible severity levels: down, disrupted, notice
 severity: notice
 
@@ -42,7 +42,7 @@ If you are aware of an incident which hasn't been posted here, feel free to crea
 ```
 ---
 title: Incident Title
-date: YYYY-MM-DD HH:MM:SS
+date: YYYY-MM-DD HH:MM:SS UTC
 resolved: false
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
@@ -66,7 +66,7 @@ If you need to inform our community but it doesn't involve any downtime then you
 ```
 ---
 title: Testing New cState Features
-date: 2019-10-04 18:05:00
+date: 2019-10-04 18:05:00 UTC
 informational: true
 section: issue
 ---

--- a/content/issues/2021-04-14-maintenance-publick8s.md
+++ b/content/issues/2021-04-14-maintenance-publick8s.md
@@ -1,0 +1,19 @@
+---
+title: AKS publick8s version update
+date: 2021-04-14 07:30:00 UTC
+resolved: true
+resolvedWhen: 2021-04-14 10:00:00 UTC
+# Possible severity levels: down, disrupted, notice
+severity: disrupted
+affected:
+  - publick8s
+section: issue
+---
+
+[INFRA-2944](https://issues.jenkins.io/browse/INFRA-2944)
+[NOTES](https://hackmd.io/EDpvZx9ZS2GWgHHqWFRDfQ?view)
+
+We'll do an AKS cluster upgrade.
+
+The service ldap.jenkins.io service will be restarted.
+All other services should remain up and running.

--- a/content/issues/2021-04-14-maintenance-publick8s.md
+++ b/content/issues/2021-04-14-maintenance-publick8s.md
@@ -1,8 +1,8 @@
 ---
 title: AKS publick8s version update
-date: 2021-04-14 07:30:00 UTC
+date: 2021-04-14T07:30:00-00:00
 resolved: true
-resolvedWhen: 2021-04-14 10:00:00 UTC
+resolvedWhen: 2021-04-14T10:00:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:


### PR DESCRIPTION
[INFRA-2944](https://issues.jenkins.io/browse/INFRA-2944)
[NOTES](https://hackmd.io/EDpvZx9ZS2GWgHHqWFRDfQ?view)

We'll do an AKS cluster upgrade.

The service ldap.jenkins.io service will be restarted.
The procedure upgrade one machine at a time so most services should remain up and running, excepted release.ci, infra.ci and the ldap service will be restarted in the process.

We didn't identify major risk for this upgrade

We are continuously improving the process so, feel free to provides feedbacks on the notes and we will incorporate them in the next upgrades.