### PR TITLE
Add Windows Weekly Package Unavailable Incident

### DIFF
--- a/content/issues/2021-05-25-weekly-windows.md
+++ b/content/issues/2021-05-25-weekly-windows.md
@@ -1,0 +1,18 @@
+---
+title: Windows Weekly Package Unavailable
+date: 2021-05-25T11:30:00-00:00
+resolved: true
+resolvedWhen: 2021-05-26T07:51:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: disrupted
+affected:
+  - jenkins.io/downloads
+  - get.jenkins.io
+  - updates.jenkins.io
+  - pkg.jenkins.io
+section: issue
+---
+
+Due to a technical issue in the release process, the Windows package for the weekly Jenkins release was unavailable from 2021-05-25 11:30 UTC until 2021-05-26 07:51 UTC.
+
+A [Post-Mortem is available on hackmd.io](https://hackmd.io/@jenkins-infra/SJNjA5jKu).


### PR DESCRIPTION
Ref. https://hackmd.io/@jenkins-infra/SJNjA5jKu

I saw https://github.com/jenkins-infra/jenkins.io/issues/4387 and I wondered if the user might have been affected.
In any case, it's good thing to add the incident even afterwards, so we can point the history later if needed.