### PR TITLE
Note ACI agent allocation outage on ci.jenkins.io

### DIFF
--- a/content/issues/2021-05-29-no-aci-agents-for-ci-jenkins-io.md
+++ b/content/issues/2021-05-29-no-aci-agents-for-ci-jenkins-io.md
@@ -1,0 +1,15 @@
+---
+title: ACI agents fail to allocate for ci.jenkins.io
+date: 2021-05-29T22:41:00-00:00
+resolved: false
+resolvedWhen: 
+# Possible severity levels: down, disrupted, notice
+severity: disrupted
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+A plugin upgrade has caused allocation of Azure Container Instances to fail on ci.jenkins.io.  Investigation is in progress to resolve the issue and identify the root cause.
+
+A [detailed timeline is available on hackmd.io](https://hackmd.io/XBFjAgkFQ1mjiKPnsW2EXw).


### PR DESCRIPTION
## Report ACI agent allocation outage on ci.jenkins.io

See https://hackmd.io/XBFjAgkFQ1mjiKPnsW2EXw for detailed timeline and exploration.  Plugin upgrade seems to have blocked allocations of ACI agents.

Signed-off-by: Mark Waite <mark.earl.waite@gmail.com>
