### PR TITLE
Switch gitsubmodule url from git to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/cstate"]
 	path = themes/cstate
-	url = git@github.com:cstate/cstate.git
+	url = https://github.com/cstate/cstate.git


### PR DESCRIPTION
For some reason that I still ignore updatecli doesn't work if we use a git URL so I am switching to a https for now
Signed-off-by: Olivier Vernin <olivier@vernin.me>