### PR TITLE
Add archives.jenkins.io outage and its resolution

### DIFF
--- a/content/issues/2021-07-16-archives-jenkins-io-unreachable.md
+++ b/content/issues/2021-07-16-archives-jenkins-io-unreachable.md
@@ -1,0 +1,15 @@
+---
+title: HTTP access to archives.jenkins.io unreachable
+date: 2021-07-16T23:50:00-00:00
+resolved: true
+resolvedWhen: 2021-07-17T15:10:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: disrupted
+affected:
+  - archives.jenkins.io
+section: issue
+---
+
+The HTTP server on archives.jenkins.io was not responding to requests.
+The mirror system on get.jenkins.io excluded archives.jenkins.io because it was unreachable.
+Issue was resolved by stopping and starting the apache2 service on the host (okra.jenkins.io).


### PR DESCRIPTION
## HTTP/HTTPS archives.jenkins.io was unreachable

Record the 15 hour outage of archives.jenkins.io HTTP and HTTPS services.  Computer was running and responding to ssh.  HTTP service was reported as healthy by systemctl, yet wget and web browser could not open the page, even from the host itself.

Stopped and started the apache2 service and that resolved the issue.
