### PR TITLE
Announce wiki SSL certificate renewal

### DIFF
--- a/content/issues/2021-08-29-wiki-maintenance.md
+++ b/content/issues/2021-08-29-wiki-maintenance.md
@@ -1,0 +1,17 @@
+---
+title: Maintenance with downtime on https://wiki.jenkins.io (Jenkins wiki)
+date: 2021-08-29T18:00:00-00:00
+resolved: false
+resolvedWhen: 2021-08-29T18:03:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: notice
+affected:
+  - wiki.jenkins.io
+  - wiki.jenkins-ci.org
+section: issue
+---
+
+SSL certificate on the Jenkins wiki will expire in 14 days.
+Restart the Apache service to use the new certificate.
+
+Downtime less than 3 minutes.


### PR DESCRIPTION
# Announce wiki SSL certificate renewal downtime

Announce wiki SSL certificate renewal.  Certificate was reporting that it would expire in 14 days, even though the updated certificate was available.  Restarted the Apache web server to use the new certificate.

Signed-off-by: Mark Waite <mark.earl.waite@gmail.com>
