### PR TITLE
Note that Jenkins wiki is offline intentionally

### DIFF
--- a/content/issues/2021-09-02-wiki-offline.md
+++ b/content/issues/2021-09-02-wiki-offline.md
@@ -1,0 +1,14 @@
+---
+title: Jenkins wiki offline due to vulnerability
+date: 2021-09-02T08:15:00-00:00
+resolved: false
+# resolvedWhen: 2021-09-30T23:59:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - wiki.jenkins.io
+  - wiki.jenkins-ci.org
+section: issue
+---
+
+Jenkins wiki, https://wiki.jenkins.io, is offline due to a remote code execution security vulnerability.


### PR DESCRIPTION
## Jenkins wiki is offline due to ssecurity vulnerability
