### PR TITLE
chore(updatecli) simplify updatecli process

### DIFF
--- a/.github/.dependabot.yaml
+++ b/.github/.dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -16,5 +16,5 @@ jobs:
       uses: klakegg/actions-hugo@1.0.0
       with:
         version: 0.87.0
-         # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)
+        # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)
         image: ext-asciidoctor

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -2,10 +2,13 @@
 name: updatecli
 
 on:
+  # Allow to be run manually
   workflow_dispatch:
   schedule:
-    # Run every 15minutes
-    - cron: '*/15 * * * *'
+    # Run once per week (to avoid alert fatigue)
+    - cron: '0 2 * * 1' # Every monday at 2am UTC
+  push:
+  pull_request:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
@@ -14,16 +17,20 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Diff
+        continue-on-error: true
         uses: updatecli/updatecli-action@v1
         with:
           command: diff
           flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.UPDATECLI_GITHUB_TOKEN }}
+          # Github "generated" token is used because the repository secrets are not available in PRs.
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Apply
         uses: updatecli/updatecli-action@v1
+        if: github.ref == 'refs/heads/main'
         with:
           command: apply
           flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
         env:
+          # Secret repository's token is used to create PRs on behalf of the jenkins-infra-bot
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.UPDATECLI_GITHUB_TOKEN }}

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -19,11 +19,11 @@ jobs:
           command: diff
           flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.UPDATECLI_GITHUB_TOKEN }}
       - name: Apply
         uses: updatecli/updatecli-action@v1
         with:
           command: apply
           flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.UPDATECLI_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 public
+.hugo_build.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-ARG HUGO_VERSION=0.87.0
-FROM klakegg/hugo:$HUGO_VERSION-asciidoctor
-
-RUN apk add --no-cache git

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,10 @@
 version: '3'
 services:
   status:
-    build: .
+    # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)
+    image: klakegg/hugo:0.87.0-ext-asciidoctor
     volumes:
-      - .:/src:ro
+      - .:/src
     ports:
-        - 1313:1313
+      - 1313:1313
     command: "serve --cleanDestinationDir --disableFastRender --path-warnings --print-mem --verbose --verboseLog --noHTTPCache"
-

--- a/updatecli/updatecli.d/hugo.yaml
+++ b/updatecli/updatecli.d/hugo.yaml
@@ -2,7 +2,7 @@
 title: "Bump Hugo version"
 sources:
   # Get Hugo Version from Github Releases
-  hugoVersion:
+  getLatestHugoVersion:
     kind: githubRelease
     name: Get the latest hugo version
     spec:
@@ -10,75 +10,28 @@ sources:
       repository: "hugo"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-      # versionFilter can't be used until we
-      # fix https://github.com/updatecli/updatecli/issues/244
-      # versionFilter:
-      #  kind: semver
-      #  pattern: "~0"
+      versionFilter:
+        kind: latest
     transformers:
       - trimPrefix: "v"
-  # Get current Hugo Version defined for Netlify
-  # so we can replace later on, the value by the updated one
-  hugoVersionFromNetlifyConfig:
-    kind: file
-    name: Get netlify configuration
-    spec:
-      file: netlify.toml
-    transformers:
-      - find: 'HUGO_VERSION = "(.*?)"'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
-  # Read netlify.toml content and update the HUGO_VERSION
-  # the content will be injected later on in the target
-  netlifyConfig:
-    kind: file
-    name: Get netlify configuration
-    depends_on:
-      - hugoVersion
-      - hugoVersionFromNetlifyConfig
-    spec:
-      file: netlify.toml
-    transformers:
-      - replacer:
-          from: '{{ source "hugoVersionFromNetlifyConfig" }}'
-          to: 'HUGO_VERSION = "{{ source "hugoVersion" }}"'
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
 conditions:
-  # Test if docker image klakegg/hugo
-  docker:
-    name: "Test if docker Image klakegg/hugoPublished is available on docker Registry"
-    sourceID: hugoVersion
+  checkIfDockerImageIsPublished:
+    transformers:
+      - addSuffix: "-asciidoctor"
+    name: "Test if the docker image 'klakegg/hugo' is available on the Dockerhub registry"
     kind: dockerImage
     spec:
       image: "klakegg/hugo"
-    transformers:
-      - addSuffix: "-asciidoctor"
 targets:
-  # Update Dockerfile
-  updateDockerfileArgHelmfileVersion:
-    name: "Update default HUGO_VERSION value in the Dockerfile"
-    kind: dockerfile
-    sourceID: hugoVersion
+  updateDockerComposeFile:
+    transformers:
+      - addSuffix: "-ext-asciidoctor"
+      - addPrefix: "klakegg/hugo:"
+    name: "Update Hugo version in docker image name in docker-compose.yaml"
+    kind: yaml
     spec:
-      file: Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "HUGO_VERSION"
+      file: docker-compose.yaml
+      key: services.status.image
     scm:
       github:
         user: "{{ .github.user }}"
@@ -88,13 +41,28 @@ targets:
         token: "{{ requiredEnv .github.token }}"
         username: "{{ .github.username }}"
         branch: "{{ .github.branch }}"
-  # Update netlify.toml
-  netlifyConfig:
+  updateNetlifyConfig:
     kind: file
-    sourceID: netlifyConfig
-    name: Get netlify configuration
+    name: "Update Hugo version in the Netlify configuration file"
     spec:
       file: netlify.toml
+      matchPattern: 'HUGO_VERSION = .*'
+      content: 'HUGO_VERSION = "{{ source `getLatestHugoVersion` }}"'
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateGitHubWorkflow:
+    kind: yaml
+    name: "Update Hugo version in the Netlify configuration file"
+    spec:
+      file: .github/workflows/hugo.yaml
+      key: jobs.build.steps[1].with.version
     scm:
       github:
         user: "{{ .github.user }}"

--- a/updatecli/values.github-action.yaml
+++ b/updatecli/values.github-action.yaml
@@ -1,7 +1,7 @@
 github:
-  user: "GitHub Actions"
-  email: "41898282+github-actions[bot]@users.noreply.github.com"
-  username: "github-actions"
+  user: "updatebot"
+  email: "updatebot@olblak.com"
+  username: "jenkins-infra-bot"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
   owner: "jenkins-infra"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,8 +1,0 @@
-github:
-  user: "updatebot"
-  email: "updatebot@olblak.com"
-  username: "olblak"
-  token: "UPDATECLI_GITHUB_TOKEN" 
-  branch: "main"
-  owner: "jenkins-infra"
-  repository: "status"


### PR DESCRIPTION
(edited)
This PR simplifies the updatecli upgrade process for hugo version:

- Stop using a Dockerfile (use the extended Hugo Docker Image instead)
- Fix docker-compose.yaml to work with the Hugo version >= 0.88 (no more read-only sharing)
- Update the updatecli manifest to these changes
- Simplify the updatecli manifest to use the latest "file matchPattern" from updatecli version >= 0.13
- Ensure that updatecli is allowed to upgrade the github workflow file by using our bot account

It also updates the github workflow to:
- Run once per week (instead of every 15 min...)
- Run the "updatecli diff" on ALL PR and commits (to ensure we don't break updatecli in a PR)
- Only run the updatecli "apply" on the principal branch