### PR TITLE
Log ci.jenkins.io upgrade from 2.319.1 to 2.319.2

### DIFF
--- a/content/issues/2022-01-12-maintenance-window-ci.md
+++ b/content/issues/2022-01-12-maintenance-window-ci.md
@@ -1,0 +1,14 @@
+---
+title: Maintenance Window on ci.jenkins.io
+date: 2022-01-12T14:44:54-00:00
+resolved: true
+resolvedWhen: 2022-01-12T16:49:55-00:00
+# Possible severity levels: down, disrupted, notice
+severity: notice
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+An upgrade of ci.jenkins.io from 2.319.1 to 2.319.2.
+See [security advisory](https://www.jenkins.io/security/advisory/2022-01-12/), [changelog](https://www.jenkins.io/changelog-stable/#v2.319.2), and [upgrade guide](https://www.jenkins.io/doc/upgrade-guide/2.319/#upgrading-to-jenkins-lts-2-319-2).


### PR DESCRIPTION
## Log ci.jenkins.io upgrade from 2.319.1 to 2.319.2
