### PR TITLE
Revert "chore: close ci.jenkins.io disruption notice"

### DIFF
--- a/content/issues/2022-01-13-issue-ci.md
+++ b/content/issues/2022-01-13-issue-ci.md
@@ -1,16 +1,13 @@
 ---
 title: Disruptions on ci.jenkins.io
 date: 2022-01-13T15:00:00-00:00
-resolved: true
-resolvedWhen: 2022-01-14T09:00:00-00:00
+resolved: false
+# resolvedWhen: 2022-01-12T16:49:55-00:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:
   - ci.jenkins.io
 section: issue
 ---
-[Final message]
-The service is back to normal.
 
-[Initial message]
 There are disruptions on the service ci.jenkins.io, see https://github.com/jenkins-infra/helpdesk/issues/2733 for more details and progress.


### PR DESCRIPTION
Reverts jenkins-infra/status#111
ci is slow again today...

Ref: https://github.com/jenkins-infra/helpdesk/issues/2733#issuecomment-1014584592 & https://github.com/jenkins-infra/helpdesk/issues/2742

