### PR TITLE
Note that repo.jenkins-ci.org was down

### DIFF
--- a/content/issues/2022-01-17-repo-jenkins-ci-org.md
+++ b/content/issues/2022-01-17-repo-jenkins-ci-org.md
@@ -1,0 +1,17 @@
+---
+title: repo.jenkins-ci.org down
+date: 2022-01-17T10:38:00-00:00
+resolvedWhen: 2022-01-17T11:27:00-00:00
+resolved: true
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - repo.jenkins-ci.org
+section: issue
+---
+[Final message]
+The service is back to normal.
+
+[Initial message]
+The service repo.jenkins-ci.org is down.
+A ticket has been raised with JFrog support.


### PR DESCRIPTION
## Record downtime of repo.jenkins-ci.org

Service is responding again.
