### PR TITLE
ci.jenkins.io disruption resolved yesterday

### DIFF
--- a/content/issues/2022-01-13-issue-ci.md
+++ b/content/issues/2022-01-13-issue-ci.md
@@ -2,7 +2,7 @@
 title: Disruptions on ci.jenkins.io
 date: 2022-01-13T15:00:00-00:00
 resolved: false
-# resolvedWhen: 2022-01-12T16:49:55-00:00
+resolvedWhen: 2022-01-21T12:30:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:


### PR DESCRIPTION
https://groups.google.com/g/jenkins-infra/c/j7M49evRXJg/m/3UhhLNl9AQAJ states that the issue is resolved.  Builds running early Jan 22, 2022 were not showing any timeout issues.  The repo.jenkins-ci.org performance was sufficient to prevent build timeouts.
