### PR TITLE
Mark the repo outage as resolved

### DIFF
--- a/content/issues/2022-01-13-issue-ci.md
+++ b/content/issues/2022-01-13-issue-ci.md
@@ -1,7 +1,7 @@
 ---
 title: Disruptions on ci.jenkins.io
 date: 2022-01-13T15:00:00-00:00
-resolved: false
+resolved: true
 resolvedWhen: 2022-01-21T12:30:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted


### PR DESCRIPTION
Earlier commit #115 said it was resolved, but did not mark it resolved
