### PR TITLE
Security advisory 2022-02-09 upgrade for ci.jenkins.io

### DIFF
--- a/content/issues/2022-02-09-maintenance-window-ci.md
+++ b/content/issues/2022-02-09-maintenance-window-ci.md
@@ -2,7 +2,7 @@
 title: Maintenance window on ci.jenkins.io
 date: 2022-02-09T12:14:28-00:00
 resolved: false
-resolvedWhen: 2022-02-09T14:00:00-00:00
+# resolvedWhen: 2022-02-09T14:00:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:

--- a/content/issues/2022-02-09-maintenance-window-ci.md
+++ b/content/issues/2022-02-09-maintenance-window-ci.md
@@ -1,0 +1,14 @@
+---
+title: Maintenance window on ci.jenkins.io
+date: 2022-02-09T13:30:00-00:00
+resolved: false
+resolvedWhen: 2022-02-09T14:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+An upgrade of ci.jenkins.io from 2.319.2 to 2.319.3.
+See [security advisory](https://www.jenkins.io/security/advisory/2022-02-09/), [changelog](https://www.jenkins.io/changelog-stable/#v2.319.3), and [upgrade guide](https://www.jenkins.io/doc/upgrade-guide/2.319/#upgrading-to-jenkins-lts-2-319-3).

--- a/content/issues/2022-02-09-maintenance-window-ci.md
+++ b/content/issues/2022-02-09-maintenance-window-ci.md
@@ -1,6 +1,6 @@
 ---
 title: Maintenance window on ci.jenkins.io
-date: 2022-02-09T13:30:00-00:00
+date: 2022-02-09T12:14:28-00:00
 resolved: false
 resolvedWhen: 2022-02-09T14:00:00-00:00
 # Possible severity levels: down, disrupted, notice


### PR DESCRIPTION
## Security advisory 2022-02-09 upgrade of ci.jenkins.io

Start time is a guess, not a commitment.
