### PR TITLE
Use notice instead of down for future events

### DIFF
--- a/content/issues/2022-02-16-maintenance-window-ci.md
+++ b/content/issues/2022-02-16-maintenance-window-ci.md
@@ -1,10 +1,11 @@
 ---
 title: Maintenance window on ci.jenkins.io
+# Insert actual start once the maintenance window opens
 date: 2022-02-16T13:30:00-00:00
 resolved: false
 # resolvedWhen: 2022-02-16T14:00:00-00:00
 # Possible severity levels: down, disrupted, notice
-severity: down
+severity: notice
 affected:
   - ci.jenkins.io
 section: issue


### PR DESCRIPTION
Correctly record the scheduled 2022-02-16 maintenance window.
