### PR TITLE
Record future maintenance as resolved

### DIFF
--- a/content/issues/2022-02-16-maintenance-window-ci.md
+++ b/content/issues/2022-02-16-maintenance-window-ci.md
@@ -2,10 +2,10 @@
 title: Maintenance window on ci.jenkins.io
 # Insert actual start once the maintenance window opens
 date: 2022-02-16T13:30:00-00:00
-resolved: false
-# resolvedWhen: 2022-02-16T14:00:00-00:00
+resolved: true
+resolvedWhen: 2022-02-16T13:45:00-00:00
 # Possible severity levels: down, disrupted, notice
-severity: notice
+severity: down
 affected:
   - ci.jenkins.io
 section: issue


### PR DESCRIPTION
No need to show that we're in the maintenance window now, since we are
not.
