### PR TITLE
close security maintenance for ci.j

### DIFF
--- a/content/issues/2022-02-15-maintenance-window-ci.md
+++ b/content/issues/2022-02-15-maintenance-window-ci.md
@@ -11,3 +11,5 @@ section: issue
 ---
 
 The 2022-02-15 at 13:30 UTC, expect an outage on ci.jenkins to update the plugins installed on this instance.
+
+Security advisory is available at <https://www.jenkins.io/security/advisory/2022-02-15/>.

--- a/content/issues/2022-02-15-maintenance-window-ci.md
+++ b/content/issues/2022-02-15-maintenance-window-ci.md
@@ -1,8 +1,8 @@
 ---
 title: Maintenance window on ci.jenkins.io (2022-02-15)
 date: 2022-02-15T13:30:00-00:00
-resolved: false
-# resolvedWhen: 2022-02-15T13:45:00-00:00
+resolved: true
+resolvedWhen: 2022-02-15T14:45:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:


### PR DESCRIPTION
Now that https://www.jenkins.io/security/advisory/2022-02-15/ is published, we can close the maintenace window.