### PR TITLE
close infra.ci maintenance

### DIFF
--- a/content/issues/2022-03-30-infra.ci-maintenance.md
+++ b/content/issues/2022-03-30-infra.ci-maintenance.md
@@ -1,8 +1,8 @@
 ---
 title: Maintenance operation on infra.ci.jenkins.io + jenkins.io's pull requests
 date: 2022-03-30T13:30:00-00:00
-#resolvedWhen: 2022-03-24T22:38:00-00:00
-resolved: false
+resolvedWhen: 2022-03-30T22:30:00-00:00
+resolved: true
 # Possible severity levels: down, disrupted, notice
 severity: notice
 affected:


### PR DESCRIPTION
This PR closes https://github.com/jenkins-infra/helpdesk/issues/2840 (maintenance on infra.ci)