### PR TITLE
Add weekly.ci.jenkins.io to status page

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -296,6 +296,12 @@ params:
       #category: Azure
       category: "[ s -> x ]"
 
+    - name: weekly.ci.jenkins.io
+      description: |
+        Jenkins instance demonstrating features running on weekly releases
+      #category: Azure
+      category: "[ s -> x ]"
+
     - name: wiki.jenkins.io
       description: |
         Service running our Confluence, service deprecated


### PR DESCRIPTION
Title says all, this PR adds weekly.ci.jenkins.io to the statuspage.