### PR TITLE
JIRA LTS Upgrade

### DIFF
--- a/content/issues/2022-04-20-issue-ci.md
+++ b/content/issues/2022-04-20-issue-ci.md
@@ -1,8 +1,8 @@
 ---
 title: Disruptions on ci.jenkins.io
-date: 2022-04-21T16:45:00-00:00
+date: 2022-04-20T16:45:00-00:00
 resolved: true
-resolvedWhen: 2022-04-22T14:45:00-00:00
+resolvedWhen: 2022-04-21T14:45:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:

--- a/content/issues/2022-04-21-issue-ci.md
+++ b/content/issues/2022-04-21-issue-ci.md
@@ -1,8 +1,8 @@
 ---
 title: Disruptions on ci.jenkins.io
 date: 2022-04-21T16:45:00-00:00
-resolved: false
-resolvedWhen:
+resolved: true
+resolvedWhen: 2022-04-22T14:45:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:
@@ -10,4 +10,8 @@ affected:
 section: issue
 ---
 
-There are disruptions on the service ci.jenkins.io, see https://github.com/jenkins-infra/helpdesk/issues/2893 for more details and progress.
+[Closing Incident]
+The service ci.jenkins.io is now performing as expected. A post-mortem is expected in the upcoming days, please follow up on the issue <https://github.com/jenkins-infra/helpdesk/issues/2893> if you are interested.
+
+[Opening Incident]
+There are disruptions on the service ci.jenkins.io, see <https://github.com/jenkins-infra/helpdesk/issues/2893> for more details and progress.

--- a/content/issues/2022-04-21-jira-lts-upgrade.md
+++ b/content/issues/2022-04-21-jira-lts-upgrade.md
@@ -1,0 +1,16 @@
+---
+title: Maintenance on issues.jenkins.io (JIRA)
+date: 2022-04-21T23:00:00-00:00
+resolved: true
+resolvedWhen: 2022-04-22T00:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: disrupted
+
+affected:
+  - issues.jenkins.io
+section: issue
+---
+
+The Linux Foundation team that maintains our Jira instance will upgrade the JIRA instance at <https://issues.jenkins.io> to the latest LTS version.
+
+More information in the following issue: <https://github.com/jenkins-infra/helpdesk/issues/2872>.


### PR DESCRIPTION
This PR updates status.jenkins.io to close https://github.com/jenkins-infra/helpdesk/issues/2872.

It also closes the ci.jenkins.io incident from the same days.