### PR TITLE
Chore: Issue to notify rating migration

### DIFF
--- a/content/issues/2022-04-28-artifactory-ui.md
+++ b/content/issues/2022-04-28-artifactory-ui.md
@@ -1,14 +1,16 @@
 ---
 title: JFrog's Artifactory WebUI unavailable (repo.jenkins-ci.org)
 date: 2022-04-28T04:47:00-00:00
-#resolvedWhen: 2022-04-30T13:36:00-00:00
-resolved: false
+resolvedWhen: 2022-04-29T15:09:00-00:00
+resolved: true
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:
   - repo.jenkins-ci.org
 section: issue
 ---
+[Closing message]
+JFrogs resolve the issue by restarting the server dealing with the UI
 
 [Initial message]
 <!-- markdown-link-check-disable-next-line -->

--- a/content/issues/2022-05-02-migration-rating.md
+++ b/content/issues/2022-05-02-migration-rating.md
@@ -1,0 +1,17 @@
+---
+title: Migration of rating.jenkins.io from amazon to azure
+date: 2022-05-03T07:30:00-00:00
+resolved: false
+#resolvedWhen: 2022-04-27T12:45:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: notice
+affected:
+  - rating.jenkins.io
+section: issue
+---
+
+We'll do a migration of rating.jenkins.io from amazon to azure this Tuesday, 6th of May 2022, starting at 7:30 UTC.
+
+See more at https://github.com/jenkins-infra/helpdesk/issues/1627
+
+No outage is expected.


### PR DESCRIPTION
update status messages for rating.jenkins.io migration + cleanup older issues on status.j

(edit)
- Related to https://github.com/jenkins-infra/helpdesk/issues/1627
- Closes https://github.com/jenkins-infra/helpdesk/issues/2904