### PR TITLE
chore(renew certif): close issue 2950

### DIFF
--- a/content/issues/2022-05-31-update-centernot-updated.md
+++ b/content/issues/2022-05-31-update-centernot-updated.md
@@ -11,7 +11,7 @@ section: issue
 ---
 
 [Close Issue]
-the new certificate had been issued and store within the trusted controller. Both the crawler an the update-center job run again smoothly.
+the new certificate had been issued and stored within the trusted controller. Both the crawler and the update-center jobs run smoothly again.
 
 [Open Issue]
 The service updates.jenkins.io, which provides a catalog of the jenkins plugins, is not updated since the 31th of May 2022, around noon UTC.

--- a/content/issues/2022-05-31-update-centernot-updated.md
+++ b/content/issues/2022-05-31-update-centernot-updated.md
@@ -1,14 +1,17 @@
 ---
 title: Update Center not updated with new released plugins
 date: 2022-05-31T12:00:00-00:00
-resolved: false
-#resolvedWhen: 2022-05-30T11:00:00-00:00
+resolved: true
+resolvedWhen: 2022-06-01T08:10:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:
   - updates.jenkins.io
 section: issue
 ---
+
+[Close Issue]
+the new certificate had been issued and store within the trusted controller. Both the crawler an the update-center job run again smoothly.
 
 [Open Issue]
 The service updates.jenkins.io, which provides a catalog of the jenkins plugins, is not updated since the 31th of May 2022, around noon UTC.

--- a/content/issues/2022-05-31-update-centernot-updated.md
+++ b/content/issues/2022-05-31-update-centernot-updated.md
@@ -2,7 +2,7 @@
 title: Update Center not updated with new released plugins
 date: 2022-05-31T12:00:00-00:00
 resolved: true
-resolvedWhen: 2022-06-01T08:10:00-00:00
+resolvedWhen: 2022-06-01T09:47:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:
@@ -11,7 +11,11 @@ section: issue
 ---
 
 [Close Issue]
-the new certificate had been issued and stored within the trusted controller. Both the crawler and the update-center jobs run smoothly again.
+the new certificate had been issued and stored within the trusted controller. Both the crawler and the update-center jobs run smoothly again since 07:34am UTC.
+
+The plugin "gap" was filled at 09:47am UTC as per <https://github.com/jenkins-infra/helpdesk/issues/2950#issuecomment-1143374848>.
+
+
 
 [Open Issue]
 The service updates.jenkins.io, which provides a catalog of the jenkins plugins, is not updated since the 31th of May 2022, around noon UTC.


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2950

update-center and crawler certificate renew.