### PR TITLE
ci.jenkins.io is offline for 2.346.1 upgrade

### DIFF
--- a/content/issues/2022-06-22-ci-outage.md
+++ b/content/issues/2022-06-22-ci-outage.md
@@ -1,0 +1,13 @@
+---
+title: Outage on ci.jenkins.io
+date: 2022-06-22T11:40:00-00:00
+resolved: false
+resolvedWhen: 2022-06-22T12:20:00-06:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+The [ci.jenkins.io](https://ci.jenkins.io) service is offline for upgrade to Jenkins 2.346.1.

--- a/content/issues/2022-06-22-ci-outage.md
+++ b/content/issues/2022-06-22-ci-outage.md
@@ -10,4 +10,4 @@ affected:
 section: issue
 ---
 
-The [ci.jenkins.io](https://ci.jenkins.io) service is offline for upgrade to Jenkins 2.346.1.
+The ci.jenkins.io service is offline for upgrade to Jenkins 2.346.1.


### PR DESCRIPTION
## ci.jenkins.io is offline for 2.346.1 upgrade
