### PR TITLE
fix: token to pull updatecli docker image

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: tibdex/github-app-token@v1.5
+        id: generate_token
+        if: github.ref == 'refs/heads/main'
+        with:
+          app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
+          private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
       - name: Diff
         continue-on-error: true
         uses: updatecli/updatecli-action@v1
@@ -23,13 +29,7 @@ jobs:
           flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
         env:
           # Github "generated" token is used because the repository secrets are not available in PRs.
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: tibdex/github-app-token@v1.5
-        id: generate_token
-        if: github.ref == 'refs/heads/main'
-        with:
-          app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
-          private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
       - name: Apply
         uses: updatecli/updatecli-action@v1
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
The [updatecli Github Action](https://github.com/jenkins-infra/status/blob/44277868bec4130621a633b0c1ad44fd296bdcae/.github/workflows/updatecli.yaml) is [failing since today](https://github.com/jenkins-infra/status/actions) (was working 5 days ago), [it doesn't manage to pull the updatecli docker](https://github.com/jenkins-infra/status/runs/7004065381?check_suite_focus=true) image:
> error pulling image configuration: download failed after attempts=1: unauthorized: unauthenticated: User cannot be authenticated with the token provided.

By moving the `generate_token` at the top, we can use the generated token in the `updatecli diff` step.