### PR TITLE
Jira down at 19:21 on 2022-09-02

### DIFF
--- a/content/issues/2022-09-02-jira-outage.md
+++ b/content/issues/2022-09-02-jira-outage.md
@@ -1,0 +1,14 @@
+---
+title: Jira (issues.jenkins.io) outage
+date: 2022-09-02T19:40:00-00:00
+resolved: false
+resolvedWhen: 2022-09-02T21:40:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, is currently down.
+
+Issue IT-24484 has been raised with the Linux Foundation.

--- a/content/issues/2022-09-02-jira-outage.md
+++ b/content/issues/2022-09-02-jira-outage.md
@@ -1,8 +1,8 @@
 ---
 title: Jira (issues.jenkins.io) outage
-date: 2022-09-02T19:40:00-00:00
+date: 2022-09-02T19:21:00-00:00
 resolved: false
-resolvedWhen: 2022-09-02T21:40:00-00:00
+resolvedWhen: 2022-09-02T21:21:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:


### PR DESCRIPTION
## Jira is down beginning at 19:21 2022-09-02 UTC
