### PR TITLE
Jira is running again

### DIFF
--- a/content/issues/2022-09-02-jira-outage.md
+++ b/content/issues/2022-09-02-jira-outage.md
@@ -1,8 +1,8 @@
 ---
 title: Jira (issues.jenkins.io) outage
-date: 2022-09-02T19:21:00-00:00
-resolved: false
-resolvedWhen: 2022-09-02T21:21:00-00:00
+date: 2022-09-02T19:33:00-00:00
+resolved: true
+resolvedWhen: 2022-09-02T21:33:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:


### PR DESCRIPTION
## Jira is running again

Updated the start of downtime and the resolution time based on monitoring data.
