### PR TITLE
feat(check-link): ignore trusted.ci.jenkins.io links

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -13,3 +13,4 @@ jobs:
       with:
         check-modified-files-only: yes
         base-branch: main
+        config-file: .github/workflows/markdown-link-check-config.json

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^http://trusted.ci.jenkins.io"
+        }
+    ]
+}


### PR DESCRIPTION
As this URL isn't reachable without a VPN connection, this PR configures the check-link GHA to ignore it so it doesn't fail when this URL is mentioned in status notices.

Ref: #224 