### PR TITLE
Plugin security advisory has ci.jenkins.io down

### DIFF
--- a/content/issues/2023-01-24-ci-down.md
+++ b/content/issues/2023-01-24-ci-down.md
@@ -1,0 +1,13 @@
+---
+title: Outage on ci.jenkins.io
+date: 2023-01-24T12:33:00-00:00
+resolved: false
+resolvedWhen: 2023-01-24T14:30:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+Updates for plugin security advisory.


### PR DESCRIPTION
## Plugin security advisory has ci.jenkins.io down

Will be online again after advisory is published.
