### PR TITLE
Announce s390x maintenance

### DIFF
--- a/content/issues/2023-02-03-s390x-agent-down.md
+++ b/content/issues/2023-02-03-s390x-agent-down.md
@@ -1,0 +1,13 @@
+---
+title: s390x agent restart on ci.jenkins.io
+date: 2023-02-03T16:00:00-05:00
+resolved: false
+resolvedWhen: 2023-02-03T22:00:00-05:00
+# Possible severity levels: down, disrupted, notice
+severity: notice
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+The IBM System 390 agent connected to ci.jenkins.io may be restarted during a maintenance window Friday 3 Feb 2023 from 4pm to 10pm ET.


### PR DESCRIPTION
IBM will be doing some maintenance on the OSS Cloud that will require all servers to be stopped and restarted.  The outage window will be set to Friday 02/03/2023 from 4pm to 10pm ET.  Your server(s) will be automatically stopped and restarted during this time.  There is no action for you at this time. 
