### PR TITLE
ci.jenkins.io down for plugin advisory

### DIFF
--- a/content/issues/2023-02-15-ci-down.md
+++ b/content/issues/2023-02-15-ci-down.md
@@ -1,0 +1,13 @@
+---
+title: Outage on ci.jenkins.io
+date: 2023-02-15T12:11:44-00:00
+resolved: false
+resolvedWhen: 2023-02-15T14:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+Updates for plugin security advisory.


### PR DESCRIPTION
## ci.jenkins.io is down for plugin advisory

Time is as reported by uptime robot.  Only checks once every 5 minutes, so may be wrong by as much as 5 minutes.
