### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,16 +1,13 @@
 name: Check links
-
 on: [pull_request]
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: check-links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        check-modified-files-only: yes
-        base-branch: main
-        config-file: .github/workflows/markdown-link-check-config.json
+      - uses: actions/checkout@v3
+      - name: check-links
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+        with:
+          check-modified-files-only: yes
+          base-branch: main
+          config-file: .github/workflows/markdown-link-check-config.json

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -9,7 +9,7 @@ jobs:
           # this is needed to checkout theme which normally come from separate git repository
           submodules: true
       - name: hugo
-        uses: klakegg/actions-hugo@1.0.0
+        uses: klakegg/actions-hugo@832127b60a59f4ac9e5adda72cc8223a9b8473a0 # 1.0.0
         with:
           version: 0.95.0
           # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,6 +1,4 @@
----
 name: updatecli
-
 on:
   # Allow to be run manually
   workflow_dispatch:
@@ -15,7 +13,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: tibdex/github-app-token@v1.8
+      - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8
         id: generate_token
         if: github.ref == 'refs/heads/main'
         with:
@@ -23,7 +21,7 @@ jobs:
           private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
       - name: Diff
         continue-on-error: true
-        uses: updatecli/updatecli-action@v2
+        uses: updatecli/updatecli-action@b6d75af3918fad64edd2867b09def45bbc003d86 # v2
         with:
           command: diff
           flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
@@ -31,7 +29,7 @@ jobs:
           # Github "generated" token is used because the repository secrets are not available in PRs.
           UPDATECLI_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
       - name: Apply
-        uses: updatecli/updatecli-action@v2
+        uses: updatecli/updatecli-action@b6d75af3918fad64edd2867b09def45bbc003d86 # v2
         if: github.ref == 'refs/heads/main'
         with:
           command: apply


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402