### PR TITLE
chore(gha) fix the updatecli workflow to use the updatecli action "installation" mode

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -27,7 +27,7 @@ jobs:
         run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           # Github "generated" token is used because the repository secrets are not available in PRs.
-          UPDATECLI_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Apply
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -19,21 +19,19 @@ jobs:
         with:
           app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
           private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
+      - name: Setup updatecli
+        uses: updatecli/updatecli-action@a149459e1feb1b410600dda2203cf1ee2afebf42 # v2
+
       - name: Diff
         continue-on-error: true
-        uses: updatecli/updatecli-action@a149459e1feb1b410600dda2203cf1ee2afebf42 # v2
-        with:
-          command: diff
-          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
+        run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           # Github "generated" token is used because the repository secrets are not available in PRs.
           UPDATECLI_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+      
       - name: Apply
-        uses: updatecli/updatecli-action@a149459e1feb1b410600dda2203cf1ee2afebf42 # v2
         if: github.ref == 'refs/heads/main'
-        with:
-          command: apply
-          flags: "--config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml"
+        run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           # Secret repository's token is used to create PRs on behalf of the jenkins-infra-bot
           UPDATECLI_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/updatecli/updatecli.d/hugo.yaml
+++ b/updatecli/updatecli.d/hugo.yaml
@@ -29,7 +29,7 @@ conditions:
   checkIfDockerImageIsPublished:
     name: "Test if the docker image 'klakegg/hugo' is available on the DockerHub registry"
     transformers:
-      - addSuffix: "-ext-asciidoctor"
+      - addsuffix: "-ext-asciidoctor"
     sourceid: getLatestDockerHugoVersion
     kind: dockerimage
     spec:
@@ -40,8 +40,8 @@ conditions:
 targets:
   updateDockerComposeFile:
     transformers:
-      - addPrefix: "klakegg/hugo:"
-      - addSuffix: "-ext-asciidoctor"
+      - addprefix: "klakegg/hugo:"
+      - addsuffix: "-ext-asciidoctor"
     name: "Update Hugo version in docker image name in docker-compose.yaml"
     kind: yaml
     spec:
@@ -64,14 +64,10 @@ targets:
       key: jobs.build.steps[1].with.version
     scmid: default
 
-pullrequests:
+actions:
   chart:
-    kind: github
+    kind: github/pullrequest
     scmid: default
-    targets:
-      - updateDockerComposeFile
-      - updateNetlifyConfig
-      - updateGitHubWorkflow
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
This PR follows up #257 .

It fixes the updatecli manifest and GHA workflow:

- Correct the GHA workflow to:
  - Use the updatecli action's install mode (instead of execute in a closed environment), which removes the warning message `Unexpected input(s) 'command', 'flags', valid inputs are ['version']` from the GHA execution
  - Use the `GITHUB_TOKEN` for the "Updatecli Diff" step so it's executed in every PR with the PR author's identity (relying on tidbex is only possible on the upstream branches)
- Correct the deprecated directives in the updatecli manifest