### PR TITLE
Announce Jira upgrade Sat 11 Mar 2023 at midnight (UTC)

### DIFF
--- a/content/issues/2023-03-11-jira-outage.md
+++ b/content/issues/2023-03-11-jira-outage.md
@@ -1,0 +1,12 @@
+---
+title: Jira (issues.jenkins.io) outage
+date: 2023-03-11T00:00:00-00:00
+resolved: false
+resolvedWhen: 2023-03-11T00:30:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: notice
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 30 minutes so that it can be upgraded.


### PR DESCRIPTION
## Announce upcoming Jira upgrade Sat 11 Mar 2023 (midnight)

The Jira instance https://issues.jenkins.io will be down for up to 30 minutes beginning at midnight on Saturday 11 Mar 2023.
