### PR TITLE
Make Jira upgrade date more visible

### DIFF
--- a/content/issues/2023-03-11-jira-outage.md
+++ b/content/issues/2023-03-11-jira-outage.md
@@ -9,4 +9,4 @@ affected:
   - issues.jenkins.io
 section: issue
 ---
-The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 30 minutes so that it can be upgraded.
+The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 30 minutes beginning at midnight (UTC) Saturday March 11, 2023 so that it can be upgraded.


### PR DESCRIPTION
## Make Jira update schedule more visible 

I assumed that the date information would be included more visibly in the page.  It is in the page, but I did not immediately see it when I read the page.

@lemeurherve thanks for the quick review of the prior notice.  Added more text so that the date is included in the text, not just in the heading at the top of the page.