### PR TITLE
Announce ci.jenkins.io down for plugin advisory

### DIFF
--- a/content/issues/2023-04-12-ci-outage.md
+++ b/content/issues/2023-04-12-ci-outage.md
@@ -1,0 +1,14 @@
+---
+title: Maintenance on ci.jenkins.io
+date: 2023-04-12:11:00:30:00
+resolved: false
+resolvedWhen: 2023-04-12:11:20-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+There is an outage on ci.jenkins.io since 11:00 UTC for plugin updates.
+The updates are part of the previously announced [plugin security advisory](https://groups.google.com/g/jenkinsci-advisories/c/oADJ7nuLF48/m/eHcQwSZ7FAAJ).

--- a/content/issues/2023-04-12-ci-outage.md
+++ b/content/issues/2023-04-12-ci-outage.md
@@ -11,4 +11,4 @@ section: issue
 ---
 
 There is an outage on ci.jenkins.io since 11:00 UTC for plugin updates.
-The updates are part of the previously announced [plugin security advisory](https://groups.google.com/g/jenkinsci-advisories/c/oADJ7nuLF48/m/eHcQwSZ7FAAJ).
+The updates are part of the previously announced [plugin security advisory](https://groups.google.com/g/jenkinsci-advisories/c/ccmIF1Vs-9A/m/GQei2TM9AAAJ).


### PR DESCRIPTION
Announced in https://groups.google.com/g/jenkinsci-advisories/c/ccmIF1Vs-9A/m/GQei2TM9AAAJ