### PR TITLE
Fix date of Jira database upgrade

### DIFF
--- a/content/issues/2023-07-06-jira-outage.md
+++ b/content/issues/2023-07-06-jira-outage.md
@@ -1,0 +1,12 @@
+---
+title: Jira (issues.jenkins.io) outage
+date: 2023-07-06T21:00:00-00:00
+resolved: false
+resolvedWhen: 2023-07-06T23:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: notice
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to two hours minutes beginning at 9:00 PM (UTC) Thursday July 16, 2023 so that it can be upgraded.

--- a/content/issues/2023-07-06-jira-outage.md
+++ b/content/issues/2023-07-06-jira-outage.md
@@ -9,4 +9,4 @@ affected:
   - issues.jenkins.io
 section: issue
 ---
-The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to two hours minutes beginning at 9:00 PM (UTC) Thursday July 16, 2023 so that it can be upgraded.
+The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to two hours minutes beginning at 9:00 PM (UTC) Thursday July 6, 2023 so that it can be upgraded.


### PR DESCRIPTION
## Fix error in text of previously approved outage announcement

- Announce Jira DB upgrade July 6, not July 16
