### PR TITLE
Increase issues.jenkins.io to 'down' for July 6 upgrade

### DIFF
--- a/content/issues/2023-07-06-jira-outage.md
+++ b/content/issues/2023-07-06-jira-outage.md
@@ -4,7 +4,7 @@ date: 2023-07-06T21:00:00-00:00
 resolved: false
 resolvedWhen: 2023-07-06T23:00:00-00:00
 # Possible severity levels: down, disrupted, notice
-severity: notice
+severity: down
 affected:
   - issues.jenkins.io
 section: issue


### PR DESCRIPTION
Assure that users can find the status during the upgrade.
