### PR TITLE
Notify users of ci.jenkins.io restart tomorrow

### DIFF
--- a/content/issues/2023-07-12-ci-maintenance.md
+++ b/content/issues/2023-07-12-ci-maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: Maintenance on ci.jenkins.io
-date: 2023-07-12T13:00:00-00:00
+date: 2023-07-12Z11:30:00-00:00
 resolved: false
 resolvedWhen: 2023-07-12T13:30:00-00:00
 # Possible severity levels: down, disrupted, notice

--- a/content/issues/2023-07-12-ci-maintenance.md
+++ b/content/issues/2023-07-12-ci-maintenance.md
@@ -1,0 +1,13 @@
+---
+title: Maintenance on ci.jenkins.io
+date: 2023-07-12T13:00:00-00:00
+resolved: false
+resolvedWhen: 2023-07-12T13:30:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: notice
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+Wednesday July 12, 2023 the ci.jenkins.io controller will be restarted if plugin updates are needed as a result of the plugin security advisory.

--- a/content/issues/2023-07-12-ci-maintenance.md
+++ b/content/issues/2023-07-12-ci-maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: Maintenance on ci.jenkins.io
-date: 2023-07-12Z11:30:00-00:00
+date: 2023-07-12T11:30:00-00:00
 resolved: false
 resolvedWhen: 2023-07-12T13:30:00-00:00
 # Possible severity levels: down, disrupted, notice
@@ -11,3 +11,7 @@ section: issue
 ---
 
 Wednesday July 12, 2023 the ci.jenkins.io controller will be restarted if plugin updates are needed as a result of the plugin security advisory.
+
+The restart may happen between 11:30am UTC and 13:30 UTC.
+
+More details in <https://groups.google.com/g/jenkinsci-advisories/c/y50ITBfDesw>.


### PR DESCRIPTION
If the plugin security advisory involves any plugins installed on ci.jenkins.io, then the controller will be restarted.
