### PR TITLE
Conclude the ci.jenkins.io outage

### DIFF
--- a/content/issues/2023-07-12-ci-maintenance.md
+++ b/content/issues/2023-07-12-ci-maintenance.md
@@ -1,15 +1,19 @@
 ---
 title: Maintenance on ci.jenkins.io
-date: 2023-07-12T11:30:00-00:00
-resolved: false
-resolvedWhen: 2023-07-12T13:30:00-00:00
+date: 2023-07-12T11:38:11-00:00
+resolved: true
+resolvedWhen: 2023-07-12T13:57:00-00:00
 # Possible severity levels: down, disrupted, notice
-severity: notice
+severity: down
 affected:
   - ci.jenkins.io
 section: issue
 ---
 
+[Final Message]
+The ci.jenkins.io controller is running with updated plugins.
+
+[Initial message]
 Wednesday July 12, 2023 the ci.jenkins.io controller will be restarted if plugin updates are needed as a result of the plugin security advisory.
 
 The restart may happen between 11:30am UTC and 13:30 UTC.


### PR DESCRIPTION
## Conclude the ci.jenkins.io outage

The ci.jenkins.io upgrade of the plugins is complete.
