### PR TITLE
open publick8s x86 nodepool migration

### DIFF
--- a/content/issues/2023-12-06-artifactory-central-brownount.md
+++ b/content/issues/2023-12-06-artifactory-central-brownount.md
@@ -1,7 +1,7 @@
 ---
 title: Brownout of the Maven Central mirrored repositories in JFrog Artifactory (repo.jenkins-ci.org)
 date: 2023-12-06T13:00:00-00:00
-resolved: false
+resolved: true
 resolvedWhen: 2023-12-06T15:00:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: notice

--- a/content/issues/2023-12-07-x86medium-migration.md
+++ b/content/issues/2023-12-07-x86medium-migration.md
@@ -1,0 +1,27 @@
+---
+title: AKS (`publick8s`) operation on the x86 nodes
+date: 2023-12-07T10:30:00-00:00
+resolved: false
+# resolvedWhen: 2023-12-07T11:30:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: disrupted
+affected:
+  - artifact-caching-proxy
+  - mirrorbits
+  - ldap
+  - keycloak
+  - falco
+  - datadog
+section: issue
+---
+
+<!--
+[FINAL]
+Aborted as not enough team members available to secure the operation
+
+[INITIAL]
+-->
+
+Thursday December 7 2023, starting at 10:30am UTC, we'll proceed to the amd/intel migration from x86medium nodepool to x86small nodepool
+
+Related help desk issue: https://github.com/jenkins-infra/helpdesk/issues/3827


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3827

Note I'm closing the jfrog brownout as it was finished in time yesterday