### PR TITLE
Announce JIRA restore on Monday Dec 18, 2023

### DIFF
--- a/content/issues/2023-12-18-jira-outage.md
+++ b/content/issues/2023-12-18-jira-outage.md
@@ -1,0 +1,14 @@
+---
+title: Jira (issues.jenkins.io) outage
+date: 2023-12-18T23:00:00-00:00
+resolved: false
+resolvedWhen: 2023-12-18T23:59:59-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 60 minutes beginning at 11:00 PM (UTC) Monday December 18, 2023 so that it can be restored from backup.
+A spammer damaged over 1000 Jenkins issue reports on Dec 6, 2023.
+We will restore a database backup that precedes the damage.


### PR DESCRIPTION
## Announce JIRA restore on Monday Dec 18, 2023

The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 60 minutes beginning at 11:00 PM (UTC) Monday December 18, 2023 so that it can be restored from backup.  A spammer damaged over 1000 Jenkins issue reports on Dec 6, 2023.  We will restore a database backup that precedes the damage.
