### PR TITLE
Resolve Artifactory notice

### DIFF
--- a/content/issues/2023-12-15-artifactory-changes.md
+++ b/content/issues/2023-12-15-artifactory-changes.md
@@ -1,7 +1,7 @@
 ---
 title: Removal of the Maven Central mirrored repositories from JFrog Artifactory (repo.jenkins-ci.org)
 date: 2023-12-15T13:00:00-00:00
-resolved: false
+resolved: true
 resolvedWhen: 2023-12-15T15:00:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: notice


### PR DESCRIPTION
## Resolve Artifactory notice

[Jenkins developer list](https://groups.google.com/g/jenkinsci-dev/c/zTXeamwCMhA/m/V1Lmo9HzDQAJ) summarizes the Artifactory configuration changes.

The change is complete and is working as expected.  Tests that were performed to confirm the change include:

* Build Jenkins core on a freshly created virtual machine
* Build Jenkins plugin bill of materials weekly line on ci.jenkins.io
* Build 20+ plugins on a freshly created virtual machine, including the plugins where issues were detected during the brownout
* Build 250 most popular plugin repositories on an existing machine (a few of them only built successfully when using the pending pull request to test with Java 21)
* Release a plugin

The transition is complete and successful.

Log files contain the expected entries downloading artifacts from Apache Maven Central when the artifact is expected to be found there.

Special thanks to Damien Duportal, Basil Crow, Daniel Beck, Bruno Verachten, and Jean-Marc Meessen for their help with the changes.

If issues are detected, please open a ticket with the [Jenkins infra help desk](https://github.com/jenkins-infra/helpdesk/issues) so that we can investigate and resolve the issue.
