### PR TITLE
Announce Jira upgrade 2023-12-27

### DIFF
--- a/content/issues/2023-12-27-jira-upgrade.md
+++ b/content/issues/2023-12-27-jira-upgrade.md
@@ -1,0 +1,12 @@
+---
+title: issues.jenkins.io (Jira) upgrade
+date: 2023-12-27T18:00:00-00:00
+resolved: false
+resolvedWhen: 2023-12-27T20:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The Jira instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to two hours beginning at 18:00 (UTC) Wednesday December 27, 2023 so that it can be upgraded.


### PR DESCRIPTION
Linux Foundation asked to do the upgrade during the holiday week.
Works great for the Jenkins project, since we have completed the weekly
release and do not have an LTS week until Jan 24, 2024.
