### PR TITLE
Close the Jira maintenance window

### DIFF
--- a/content/issues/2023-12-27-jira-upgrade.md
+++ b/content/issues/2023-12-27-jira-upgrade.md
@@ -1,7 +1,7 @@
 ---
 title: issues.jenkins.io (Jira) upgrade
 date: 2023-12-27T18:00:00-00:00
-resolved: false
+resolved: true
 resolvedWhen: 2023-12-27T20:00:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down


### PR DESCRIPTION
## Close the Jira maintenance window

Our contact at the Linux Foundation wrote:

> I was not able to complete the upgrade to 9.4.14 within the maintenance window, and have rolled back to the previous version of 9.4.7.
> 
> System updates were successfully applied, but the Jira upgrade will have to have further research and another scheduled maintenance window.
> 
> I'll post here again as soon as I find the path forward so we can schedule another maintenance window.
