### PR TITLE
Announce Jira upgrade 29 Dec 2023 at 18:00 UTC

### DIFF
--- a/content/issues/2023-12-29-jira-upgrade.md
+++ b/content/issues/2023-12-29-jira-upgrade.md
@@ -1,0 +1,12 @@
+---
+title: issues.jenkins.io (Jira) upgrade
+date: 2023-12-29T18:00:00-00:00
+resolved: false
+resolvedWhen: 2023-12-29T20:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The Jira instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to two hours beginning at 18:00 (UTC) Friday December 29, 2023 so that it can be upgraded.

--- a/content/issues/2023-12-29-jira-upgrade.md
+++ b/content/issues/2023-12-29-jira-upgrade.md
@@ -2,11 +2,12 @@
 title: issues.jenkins.io (Jira) upgrade
 date: 2023-12-29T18:00:00-00:00
 resolved: false
-resolvedWhen: 2023-12-29T20:00:00-00:00
+resolvedWhen: 2023-12-29T18:30:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:
   - issues.jenkins.io
 section: issue
 ---
-The Jira instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to two hours beginning at 18:00 (UTC) Friday December 29, 2023 so that it can be upgraded.
+The Jira instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 30 minutes beginning at 18:00 (UTC) Friday December 29, 2023.
+The Jira instance will be upgraded to a newer release.


### PR DESCRIPTION
## Announce Jira upgrade 29 Dec 2023 at 18:00 UTC

Discussed with the Linux Foundation administrators in IT-26310 ticket.
