### PR TITLE
Replace klakegg containers with floryn90 containers

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -9,7 +9,7 @@ jobs:
           # this is needed to checkout theme which normally come from separate git repository
           submodules: true
       - name: hugo
-        uses: floryn90/actions-hugo@1.0.0
+        uses: klakegg/actions-hugo@832127b60a59f4ac9e5adda72cc8223a9b8473a0 # 1.0.0
         with:
           version: 0.121.1
           # "ext-" for the Hugo extended edition including git (https://github.com/floryn90/docker-hugo/blob/master/README.md#hugo-extended-edition)

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -9,8 +9,8 @@ jobs:
           # this is needed to checkout theme which normally come from separate git repository
           submodules: true
       - name: hugo
-        uses: klakegg/actions-hugo@832127b60a59f4ac9e5adda72cc8223a9b8473a0 # 1.0.0
+        uses: floryn90/actions-hugo@1.0.0
         with:
-          version: 0.95.0
-          # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)
+          version: 0.121.1
+          # "ext-" for the Hugo extended edition including git (https://github.com/floryn90/docker-hugo/blob/master/README.md#hugo-extended-edition)
           image: ext-asciidoctor

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -11,6 +11,6 @@ jobs:
       - name: hugo
         uses: floryn90/actions-hugo@1.0.1
         with:
-          version: 0.121.1
+          version: 0.121.2
           # "ext-" for the Hugo extended edition including git (https://github.com/floryn90/docker-hugo/blob/master/README.md#hugo-extended-edition)
           image: ext-asciidoctor

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -9,8 +9,8 @@ jobs:
           # this is needed to checkout theme which normally come from separate git repository
           submodules: true
       - name: hugo
-        uses: klakegg/actions-hugo@832127b60a59f4ac9e5adda72cc8223a9b8473a0 # 1.0.0
+        uses: floryn90/actions-hugo@1.0.1
         with:
-          version: 0.95.0
-          # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)
+          version: 0.121.1
+          # "ext-" for the Hugo extended edition including git (https://github.com/floryn90/docker-hugo/blob/master/README.md#hugo-extended-edition)
           image: ext-asciidoctor

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -11,6 +11,6 @@ jobs:
       - name: hugo
         uses: klakegg/actions-hugo@832127b60a59f4ac9e5adda72cc8223a9b8473a0 # 1.0.0
         with:
-          version: 0.121.1
-          # "ext-" for the Hugo extended edition including git (https://github.com/floryn90/docker-hugo/blob/master/README.md#hugo-extended-edition)
+          version: 0.95.0
+          # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)
           image: ext-asciidoctor

--- a/README.adoc
+++ b/README.adoc
@@ -104,7 +104,7 @@ You can now execute the website locally:
 
 [source,bash]
 --
-docker compose up --build --force-recreate
+RUN_AS_USER=$(id -u):$(id -g) docker compose up --build --force-recreate
 --
 
 You can then access it at http://localhost:1313/.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   status:
-    # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)
-    image: klakegg/hugo:0.95.0-ext-asciidoctor
+    # "ext-" for the Hugo extended edition including git (https://github.com/floryn90/docker-hugo/blob/master/README.md#hugo-extended-edition)
+    image: floryn90/hugo:0.121.1-ext-asciidoctor
     volumes:
       - .:/src
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,4 +6,4 @@ services:
       - .:/src
     ports:
       - 1313:1313
-    command: "serve --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --verbose --noHTTPCache"
+    command: "serve --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --logLevel info --noHTTPCache"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,4 +6,4 @@ services:
       - .:/src
     ports:
       - 1313:1313
-    command: "serve --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --logLevel info --noHTTPCache"
+    command: "server --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --logLevel info --noHTTPCache"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,10 @@
 services:
   status:
     # "ext-" for the Hugo extended edition including git (https://github.com/floryn90/docker-hugo/blob/master/README.md#hugo-extended-edition)
+    user: ${RUN_AS_USER}
     image: floryn90/hugo:0.121.1-ext-asciidoctor
     volumes:
       - .:/src
     ports:
       - 1313:1313
-    command: "server --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --logLevel info --noHTTPCache"
+    command: "server --cleanDestinationDir --disableFastRender --logLevel info --noBuildLock --printPathWarnings --printMemoryUsage --noHTTPCache"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   status:
     # "ext-" for the Hugo extended edition including git (https://github.com/floryn90/docker-hugo/blob/master/README.md#hugo-extended-edition)
     user: ${RUN_AS_USER}
-    image: floryn90/hugo:0.121.1-ext-asciidoctor
+    image: floryn90/hugo:0.121.2-ext-asciidoctor
     volumes:
       - .:/src
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,4 +6,4 @@ services:
       - .:/src
     ports:
       - 1313:1313
-    command: "serve --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --verbose --verboseLog --noHTTPCache"
+    command: "serve --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --verbose --noHTTPCache"

--- a/updatecli/updatecli.d/hugo.yaml
+++ b/updatecli/updatecli.d/hugo.yaml
@@ -18,7 +18,7 @@ sources:
     kind: githubrelease
     name: Get the latest hugo version
     spec:
-      owner: "klakegg"
+      owner: "floryn90"
       repository: "docker-hugo"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
@@ -27,20 +27,20 @@ sources:
 
 conditions:
   checkIfDockerImageIsPublished:
-    name: "Test if the docker image 'klakegg/hugo' is available on the DockerHub registry"
+    name: "Test if the docker image 'floryn90/hugo' is available on the DockerHub registry"
     transformers:
       - addsuffix: "-ext-asciidoctor"
     sourceid: getLatestDockerHugoVersion
     kind: dockerimage
     spec:
-      image: "klakegg/hugo"
+      image: "floryn90/hugo"
       architecture: amd64
       # Tag comes from the sourceid (+ transformation)
 
 targets:
   updateDockerComposeFile:
     transformers:
-      - addprefix: "klakegg/hugo:"
+      - addprefix: "floryn90/hugo:"
       - addsuffix: "-ext-asciidoctor"
     name: "Update Hugo version in docker image name in docker-compose.yaml"
     kind: yaml


### PR DESCRIPTION
## Replace klakegg containers with floryn90 containers

The [container images](https://github.com/klakegg/docker-hugo) we have used are no longer maintained (as evidence by outdated versions and [no responses to issue reports](https://github.com/klakegg/docker-hugo/issues)).  This switches to a fork of the original repository based on a [comment](https://github.com/klakegg/docker-hugo/issues/87#issuecomment-1817545312) in one of the issues in the original repository.  The [fork](https://github.com/floryn90/docker-hugo) is being maintained and is kept current with Hugo releases.  It does not yet publish a GitHub action, so it is not yet a complete replacement for the klakegg repository.

- Replace klakegg containers with floryn90 containers
- Remove unsupported verboseLog command line flag
- Stop using deprecated --verbose
- Use server command, not serve command
- Run container as current user to avoid git issues

Upgrades to the most recent Hugo release and adapts the build process to the newest release of command line git.

## Known issues with this pull request

This pull request does not update the GitHub action to a newer version because the action is not available from the floryn90 fork.  It only updates the configuration in the Docker compose definition.