### PR TITLE
Schedule 2024-03-12 Jira upgrade

### DIFF
--- a/content/issues/2024-03-12-jira-upgrade.md
+++ b/content/issues/2024-03-12-jira-upgrade.md
@@ -1,0 +1,13 @@
+---
+title: issues.jenkins.io (Jira) upgrade
+date: 2024-03-12T23:00:00-00:00
+resolved: false
+resolvedWhen: 2024-03-13T02:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The Jira instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 3 hours beginning at 23:00 (UTC) Tuesday March 12, 2024.
+The Jira instance will be upgraded to a newer release.


### PR DESCRIPTION
## Schedule 2024-03-12 Jira upgrade

Message from our contact at the Linux Foundation:

> I'd like to schedule the maintenance window for this upgrade. It appears that it can be accomplished in one step, going from 9.4.14 where we are now to 9.12.4. So that means less time than is required for multiple small upgrades. But the upgrade will trigger a full re-index. I'm guessing that could take about 30 minutes. Does that sound right based on your experience?  Other things to be aware of:
> 
> * 9.5 updates log4j and introduces breaking changes to the log4j config
> * 9.10 triggers the full re-index
> * 9.12 is the last version to support server licenses, but we are on data center, so this is fine
> * 9.12 introduces lots of changes to jira automation. Is that in use by you?  https://confluence.atlassian.com/jirasoftware/jira-software-9-12-x-upgrade-notes-1318887012.html
> * 9.12 also introduces version incompatibility between tomcat and newrelic plugins
> 
> I think my strategy of upgrading all plugins without changing configuration will work here, but it is possible that customizations to Jira Automation or New Relic plugins would require special treatment. If they exist.
> 
> I suggest that this window should be 3 hours with the high probability of only using the first 90 minutes.

Refer to the [Linux Foundation status page](https://status.linuxfoundation.org/incidents/d6c890x0lrlp) for their status reports on the upgrade.