### PR TITLE
Drop a link to the linux foundation status page for the upcoming Jira upgrade

### DIFF
--- a/content/issues/2024-03-12-jira-upgrade.md
+++ b/content/issues/2024-03-12-jira-upgrade.md
@@ -11,3 +11,4 @@ section: issue
 ---
 The Jira instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 3 hours beginning at 23:00 (UTC) Tuesday March 12, 2024.
 The Jira instance will be upgraded to a newer release.
+Track the upgrade on the [Linux Foudnation status page](https://status.linuxfoundation.org/incidents/d6c890x0lrlp).


### PR DESCRIPTION
Like last time, the linux foundation will post progress updates on its status page.