### PR TITLE
fix: add time zone to the dates

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -325,7 +325,7 @@ params:
   #
   # dateFormat Default: "January 2, 2006 at 3:04 PM"
   # shortDateFormat Default: "15:04 — Jan 2"
-  dateFormat: January 2, 2006 at 3:04 PM
+  dateFormat: January 2, 2006 at 3:04 PM UTC
   shortDateFormat: 15:04 — Jan 2
 
   # What header design should we use?


### PR DESCRIPTION
this PR is addressing [issue#8](https://github.com/jenkins-infra/status/issues/8)

since time zone is always listed as UTC
the solution was updating the configuration file to specify the time zone in dates

## **Before:**

![image](https://github.com/jenkins-infra/status/assets/76218033/2520024d-1c72-4c64-957c-6609bdd6d308)

## **After:**

![image](https://github.com/jenkins-infra/status/assets/76218033/12a4b7c4-deb9-4278-be1a-e299488404d2)
