### PR TITLE
Use UTC time zone for all issues

### DIFF
--- a/content/issues/2022-04-12-ci-outage.md
+++ b/content/issues/2022-04-12-ci-outage.md
@@ -1,8 +1,8 @@
 ---
 title: Outage on ci.jenkins.io
-date: 2022-04-12T05:07:00-06:00
+date: 2022-04-12T11:07:00-00:00
 resolved: true
-resolvedWhen: 2022-04-12T06:20:26-06:00
+resolvedWhen: 2022-04-12T12:20:26-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:

--- a/content/issues/2022-05-01-ci-outage.md
+++ b/content/issues/2022-05-01-ci-outage.md
@@ -1,8 +1,8 @@
 ---
 title: Outage on ci.jenkins.io
-date: 2022-05-01T06:58:27-06:00
+date: 2022-05-01T12:58:27-00:00
 resolved: true
-resolvedWhen: 2022-05-01T07:59:33-06:00
+resolvedWhen: 2022-05-01T13:59:33-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:


### PR DESCRIPTION
## Use UTC time zone in issue data

TIme is not reported correctly by cState if a time zone offset is included in the data.  Always use timezone offset 00:00
