### PR TITLE
ci.jenkins.io down for plugin updates

### DIFF
--- a/content/issues/2024-05-02-ci.jenkins.io-outage.md
+++ b/content/issues/2024-05-02-ci.jenkins.io-outage.md
@@ -1,0 +1,13 @@
+---
+title: Maintenance on ci.jenkins.io
+date: 2024-05-02T10:53:00-00:00
+resolved: false
+resolvedWhen: 2024-05-02T13:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+Plugin updates are being applied for the Jenkine security advisory.


### PR DESCRIPTION
## ci.jenkins.io is down for plugin security updates

Updates are part of the plugin security advisory that was [announced to the Jenkins advisories mailing list](https://groups.google.com/g/jenkinsci-advisories/c/7u4u0lHbDEc/m/5CDiGkosBAAJ) two days ago.
