### PR TITLE
Resolve ci.jenkins.io outage

### DIFF
--- a/content/issues/2024-05-02-ci.jenkins.io-outage.md
+++ b/content/issues/2024-05-02-ci.jenkins.io-outage.md
@@ -1,8 +1,8 @@
 ---
 title: Maintenance on ci.jenkins.io
 date: 2024-05-02T10:53:00-00:00
-resolved: false
-resolvedWhen: 2024-05-02T13:00:00-00:00
+resolved: true
+resolvedWhen: 2024-05-02T12:58:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:


### PR DESCRIPTION
## Resolve ci.jenkins.io outage

Uptime robot reported time is included in the data.  Note that they only check every few minutes, so there is some inaccuracy in the reported value.
