### PR TITLE
Announce Jira upgrade Wed 26 Jun 2024 at 23:00 UTC

### DIFF
--- a/content/issues/2024-06-26-jira-upgrade.md
+++ b/content/issues/2024-06-26-jira-upgrade.md
@@ -1,0 +1,13 @@
+---
+title: issues.jenkins.io (Jira) upgrade
+date: 2024-06-26T23:00:00-00:00
+resolved: false
+resolvedWhen: 2024-06-26T23:45:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The Jira issue tracker at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 45 minutes beginning at 23:00 (UTC) Wednesday June 26, 2024.
+The Jira issue tracker will be upgraded to a newer release.


### PR DESCRIPTION
## Announce Jira upgrade Wed 26 Jun 2024 at 23:00 UTC

Ryan Day of the Linux Foundation team will perform the upgrade.
