### PR TITLE
open UC brownout operation 2

### DIFF
--- a/content/issues/2024-09-06-UC-1hour-brownout-1.md
+++ b/content/issues/2024-09-06-UC-1hour-brownout-1.md
@@ -1,0 +1,21 @@
+---
+title: Update Center Brownout (1)
+date: 2024-09-06T07:00:00-00:00
+resolved: false
+resolvedWhen: 2024-09-06T08:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: notice
+affected:
+  - updates.jenkins.io
+section: issue
+---
+
+Friday 6 September 2024 at 07:00am UTC, the service <https://updates.jenkins.io> will switch its implementation to a new system during 1 hour.
+
+All Jenkins users are impacted but should not see any functional change.
+
+⚠️ Please, check that your organization respects the advertised DNS TTL or you might be stuck in the brownout longer that expected.
+
+Under the hood, any HTTP request made to this service will be redirected to a mirror close to user locations during these brownouts.
+
+More details in <https://github.com/jenkins-infra/helpdesk/issues/2649>.

--- a/content/issues/2024-09-09-UC-1hour-brownout-2.md
+++ b/content/issues/2024-09-09-UC-1hour-brownout-2.md
@@ -1,8 +1,8 @@
 ---
-title: Update Center Brownout (1)
-date: 2024-09-06T07:00:00-00:00
-resolved: true
-resolvedWhen: 2024-09-06T08:00:00-00:00
+title: Update Center Brownout (2)
+date: 2024-09-09T14:00:00-00:00
+resolved: false
+resolvedWhen: 2024-09-09T15:00:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: notice
 affected:
@@ -10,7 +10,7 @@ affected:
 section: issue
 ---
 
-Friday 6 September 2024 at 07:00am UTC, the service <https://updates.jenkins.io> will switch its implementation to a new system during 1 hour.
+Monday 9 September 2024 at 02:00pm UTC, the service <https://updates.jenkins.io> will switch its implementation to a new system during 1 hour.
 
 All Jenkins users are impacted but should not see any functional change.
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2330934069

Follow up of #537 


Keeping as draft until the first brownout is finished