### PR TITLE
ci.jenkins.io is down for a security update

### DIFF
--- a/content/issues/2024-10-02-ci.jenkins.io-outage.md
+++ b/content/issues/2024-10-02-ci.jenkins.io-outage.md
@@ -1,0 +1,13 @@
+---
+title: Maintenance on ci.jenkins.io
+date: 2024-10-02T11:19:00-00:00
+resolved: false
+resolvedWhen: 2024-10-02T15:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+Jenkins core update is being applied for the [Jenkins security advisory](https://groups.google.com/g/jenkinsci-advisories/c/dszNG7XKdKU/m/IvT63YLiAgAJ).


### PR DESCRIPTION
## ci.jenkins.io is down for a security update

Advisory was announced in the security group last week:

https://groups.google.com/g/jenkinsci-advisories/c/dszNG7XKdKU/m/IvT63YLiAgAJ
