### PR TITLE
chore:  switch to `hugomods/hugo` Docker image, with Hugo `0.128.0`

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -8,9 +8,5 @@ jobs:
         with:
           # this is needed to checkout theme which normally come from separate git repository
           submodules: true
-      - name: hugo
-        uses: klakegg/actions-hugo@832127b60a59f4ac9e5adda72cc8223a9b8473a0 # 1.0.0
-        with:
-          version: 0.95.0
-          # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)
-          image: ext-asciidoctor
+      - name: Check site can be built with the docker compose image
+        run: docker compose --profile=donotstart up build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,5 @@
 x-base: &base
-  image: hugomods/hugo:ci-0.95.0
+  image: hugomods/hugo:ci-0.128.0
   volumes:
     - .:/src
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,15 @@
+x-base: &base
+  image: hugomods/hugo:ci-0.95.0
+  volumes:
+    - .:/src
+
 services:
   status:
-    # "ext-" for the Hugo extended edition including git (https://github.com/klakegg/docker-hugo/blob/master/README.md#hugo-extended-edition)
-    image: klakegg/hugo:0.95.0-ext-asciidoctor
-    volumes:
-      - .:/src
+    <<: *base
     ports:
       - 1313:1313
-    command: "serve --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --verbose --verboseLog --noHTTPCache"
+    command: "hugo serve --bind 0.0.0.0 --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --noHTTPCache"
+  build:
+    <<: *base
+    profiles:
+      - donotstart

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     functions = "functions"
 
 [build.environment]
-    HUGO_VERSION = "0.95.0"
+    HUGO_VERSION = "0.128.0"
 
 [[headers]]
     for = "/*.json"
@@ -14,7 +14,7 @@
 [context.production.environment]
     HUGO_ENV = "production"
     NODE_ENV = "production"
-    HUGO_VERSION = "0.95.0"
+    HUGO_VERSION = "0.128.0"
 
 [context.deploy-preview]
     command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"

--- a/updatecli/updatecli.d/hugo.yaml
+++ b/updatecli/updatecli.d/hugo.yaml
@@ -14,39 +14,38 @@ scms:
 
 sources:
   # Get Hugo Version from Github Releases
-  getLatestDockerHugoVersion:
+  getLatestVersion:
     kind: githubrelease
     name: Get the latest hugo version
     spec:
-      owner: "klakegg"
-      repository: "docker-hugo"
+      owner: gohugoio
+      repository: hugo
       token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-      versionfilter:
-        kind: latest
+    transformers:
+      - trimprefix: v
 
 conditions:
   checkIfDockerImageIsPublished:
-    name: "Test if the docker image 'klakegg/hugo' is available on the DockerHub registry"
+    name: "Test if the docker image 'hugomods/hugo:ci-<version>' is available on the DockerHub registry"
+    sourceid: getLatestVersion
     transformers:
-      - addsuffix: "-ext-asciidoctor"
-    sourceid: getLatestDockerHugoVersion
+      - addprefix: 'ci-'
     kind: dockerimage
     spec:
-      image: "klakegg/hugo"
+      image: "hugomods/hugo"
       architecture: amd64
       # Tag comes from the sourceid (+ transformation)
 
 targets:
   updateDockerComposeFile:
-    transformers:
-      - addprefix: "klakegg/hugo:"
-      - addsuffix: "-ext-asciidoctor"
     name: "Update Hugo version in docker image name in docker-compose.yaml"
+    transformers:
+      - addprefix: "hugomods/hugo:ci-"
     kind: yaml
     spec:
+      engine: yamlpath
       file: docker-compose.yaml
-      key: services.status.image
+      key: $.x-base.image
     scmid: default
   updateNetlifyConfig:
     kind: file
@@ -54,21 +53,14 @@ targets:
     spec:
       file: netlify.toml
       matchpattern: "HUGO_VERSION = .*"
-      content: 'HUGO_VERSION = "{{ source `getLatestDockerHugoVersion` }}"'
-    scmid: default
-  updateGitHubWorkflow:
-    kind: yaml
-    name: "Update Hugo version in the Netlify configuration file"
-    spec:
-      file: .github/workflows/hugo.yaml
-      key: jobs.build.steps[1].with.version
+      content: 'HUGO_VERSION = "{{ source `getLatestVersion` }}"'
     scmid: default
 
 actions:
   chart:
     kind: github/pullrequest
     scmid: default
-    title: Bump Hugo version to {{ source `getLatestDockerHugoVersion` }}
+    title: Bump Hugo version to {{ source `getLatestVersion` }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
Closes #455  and #473 

This PR switches to a new Docker image (https://docker.hugomods.com/docs/introduction/), currently community managed and widely used as the default for GoHugo since there are no official Docker image.

This image is part of the Docker OSS program (like Jenkins):
- Trustable
- No rate limit
- Support of arm64 (along usual x86_64)

Notes: 
- updatecli has been tested locally, but the check will fail until the PR is merged. We expect a PR to bump Hugo to 0.138.0 once merged
- The GHA workflow now reuses the docker compose to verify that both the site code AND the provided GoHugo setup works (in case of version bump)