### PR TITLE
Announce Jira upgrade and restart

### DIFF
--- a/content/issues/2024-11-11-jira-upgrade-and-restart.md
+++ b/content/issues/2024-11-11-jira-upgrade-and-restart.md
@@ -1,0 +1,12 @@
+---
+title: Jira (issues.jenkins.io) upgrade and restart
+date: 2024-11-11T23:00:00-00:00
+resolved: false
+resolvedWhen: 2024-11-11T23:15:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The JIRA instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 15 minutes beginning at 23:00 (UTC) Monday November 11, 2024 so that it can be upgraded and restarted.


### PR DESCRIPTION
## Announce Jira upgrade and restart

The [Linux Foundation IT ticke]t(https://jira.linuxfoundation.org/plugins/servlet/desk/portal/2/IT-27416) notes that we've seen an increase in response time on issues.jenkins.io in the last week.  The upgrade and restart is hoped to resolve the issue with the response time.
