### PR TITLE
open ci.jio upcoming operations

### DIFF
--- a/content/issues/2024-11-13-ci-maintenance.md
+++ b/content/issues/2024-11-13-ci-maintenance.md
@@ -1,0 +1,24 @@
+---
+title: Maintenance on ci.jenkins.io (Security Advisory)
+date: 2024-11-13T12:30:00-00:00
+resolved: false
+resolvedWhen: 2024-11-13T14:30:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+<!--
+
+[Final Message]
+The ci.jenkins.io controller is running with updated plugins and Core.
+
+[Initial message]
+
+-->
+
+Wednesday November 13 2024, the `ci.jenkins.io` controller will be put offline and restarted if plugin updates are needed as a result of a plugin security advisory.
+
+More details in <https://groups.google.com/g/jenkinsci-advisories/c/UmiH1ZpJez4>.

--- a/content/issues/2024-11-14-ci-maintenance.md
+++ b/content/issues/2024-11-14-ci-maintenance.md
@@ -1,0 +1,15 @@
+---
+title: Maintenance on ci.jenkins.io (Datadog plugin upgrade)
+date: 2024-11-14T08:00:00-00:00
+resolved: false
+resolvedWhen: 2024-11-14T09:30:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: notice
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+Thursday November 14 2024, the `ci.jenkins.io` controller will be restarted to upgrade the `datadog` plugin as per <https://github.com/jenkins-infra/helpdesk/issues/>.
+
+If this operation ends up in corrupting the build log like the previous ones, we'll immediately restore the backup and restart the controller.


### PR DESCRIPTION
We have 2 upcoming operations on ci.jenkins.io:

- Today (13 Nov.), Security Advisory - ref. https://groups.google.com/g/jenkinsci-advisories/c/UmiH1ZpJez4
- Thursday (14 Nov.), Datadog plugin upgrade - ref. https://github.com/jenkins-infra/helpdesk/issues/4377