### PR TITLE
chore: fix tracking of Hugo version by updatecli by removing YAML anchor in Docker Compose

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -8,5 +8,10 @@ jobs:
         with:
           # this is needed to checkout theme which normally come from separate git repository
           submodules: true
-      - name: Check site can be built with the docker compose image
-        run: docker compose --profile=donotstart up build
+      - name: Check site can be started in background with docker compose and work as expected
+        run: |
+          docker compose up --detach
+          sleep 5
+          curl --fail --verbose http://localhost:1313 --output /dev/null
+      - name: Check hugo binary is present and can be executed (inside container)
+        run: docker compose exec status hugo version

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,8 @@
-x-base: &base
-  image: hugomods/hugo:ci-0.128.0
-  volumes:
-    - .:/src
-
 services:
   status:
-    <<: *base
+    image: hugomods/hugo:ci-0.128.0
+    volumes:
+      - .:/src
     ports:
       - 1313:1313
     command: "hugo serve --bind 0.0.0.0 --cleanDestinationDir --disableFastRender --printPathWarnings --printMemoryUsage --noHTTPCache"
-  build:
-    <<: *base
-    profiles:
-      - donotstart

--- a/updatecli/updatecli.d/hugo.yaml
+++ b/updatecli/updatecli.d/hugo.yaml
@@ -45,7 +45,7 @@ targets:
     spec:
       engine: yamlpath
       file: docker-compose.yaml
-      key: $.x-base.image
+      key: $.services.status.image
     scmid: default
   updateNetlifyConfig:
     kind: file


### PR DESCRIPTION
Fixup of #551 

This PR removes the Docker Compose file YAML anchors as [not supported by `updatecli`](https://github.com/updatecli/updatecli/issues/1332) (creates PR with garbage in the YAML file making it unparseable).

It updates the `updatecli` manifest accordingly, along with the GHA workflow used to verify hugo.


Tested the updatecli manifest (as the check will fail in the PR) locally and got the following result:

```diff
diff --git a/docker-compose.yaml b/docker-compose.yaml
index 3cea750..5ac4177 100644
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   status:
-    image: hugomods/hugo:ci-0.128.0
+    image: hugomods/hugo:ci-0.138.0
     volumes:
       - .:/src
     ports:
diff --git a/netlify.toml b/netlify.toml
index 623ac48..ce68f10 100644
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     functions = "functions"
 
 [build.environment]
-    HUGO_VERSION = "0.128.0"
+    HUGO_VERSION = "0.138.0"
 
 [[headers]]
     for = "/*.json"
@@ -14,7 +14,7 @@
 [context.production.environment]
     HUGO_ENV = "production"
     NODE_ENV = "production"
-    HUGO_VERSION = "0.128.0"
+    HUGO_VERSION = "0.138.0"
 
 [context.deploy-preview]
     command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"

```