### PR TITLE
Update Jenkins Jira from 23:00 UTC to 23:59 UTC today

### DIFF
--- a/content/issues/2024-12-10-jira-upgrade-and-restart.md
+++ b/content/issues/2024-12-10-jira-upgrade-and-restart.md
@@ -1,0 +1,12 @@
+---
+title: Jira (issues.jenkins.io) upgrade and restart
+date: 2024-12-10T23:00:00-00:00
+resolved: false
+resolvedWhen: 2024-12-10T23:59:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - issues.jenkins.io
+section: issue
+---
+The Jira instance at issues.jenkins.io, managed by the Linux Foundation team, will be down for up to 30 minutes beginning at 23:00 (UTC) Monday November 11, 2024 so that it can be upgraded and restarted.


### PR DESCRIPTION
## Update Jenkins Jira from 23:00 UTC to 23:59 UTC today

Install more recent patch versions to resolve Jira administrative warnings.
