### PR TITLE
Close the Jira outage, update resolution time

### DIFF
--- a/content/issues/2024-12-10-jira-upgrade-and-restart.md
+++ b/content/issues/2024-12-10-jira-upgrade-and-restart.md
@@ -1,8 +1,8 @@
 ---
 title: Jira (issues.jenkins.io) upgrade and restart
 date: 2024-12-11T00:00:00-00:00
-resolved: false
-resolvedWhen: 2024-12-11T00:59:00-00:00
+resolved: true
+resolvedWhen: 2024-12-11T00:15:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:


### PR DESCRIPTION
## Close the Jira outage, update resolution time

Resolved in 15 minutes rather than 30 minutes.  Thanks to Ryan Day at
Linux Foundation.

