### PR TITLE
Fix services page text color on Firefox

### DIFF
--- a/layouts/services/list.html
+++ b/layouts/services/list.html
@@ -24,7 +24,7 @@
         <div>
           {{ range .Paginator.Pages }}
           <button type="button">
-            <a href="{{ .Params.Service.URL }}">{{ .Title }}</a>
+            <a href="{{ .Params.Service.URL }}" style="color: black;">{{ .Title }}</a>
           </button>
           {{ end }}
         </div>


### PR DESCRIPTION
### Fixed issue #582 

### Changes 
Added inline styling `style="color: black;"` to explicitly set the text color for better visibility in `layouts/services/list.html` file.
The repository currently does not contain a global `.css` file, so modifying styles globally was not an option.

### Testing
Tested with docker engine (suggested in readme)

Before :

![image](https://github.com/user-attachments/assets/cb6d2358-221e-4b04-be55-7c30b8ad0c58)

After :

![image](https://github.com/user-attachments/assets/2e913d95-0762-4fcd-85fa-afcecc6207f8)

## Review
Please suggest any changes that needs to be done, if required