### PR TITLE
Resolve the ci.jenkins.io outage

### DIFF
--- a/content/issues/2025-02-14-aws.ci.jenkins.io-outage.md
+++ b/content/issues/2025-02-14-aws.ci.jenkins.io-outage.md
@@ -1,8 +1,8 @@
 ---
 title: Outage on ci.jenkins.io
 date: 2025-02-14T08:30:00-00:00
-resolved: false
-#resolvedWhen: 2025-02-14T08:30:00-00:00
+resolved: true
+resolvedWhen: 2025-02-14T13:30:00-00:00
 # Possible severity levels: down, disrupted, notice
 severity: down
 affected:


### PR DESCRIPTION
## Resolve the ci.jenkins.io outage

Was resolved the same day that it was opened

Ongoing investigations of various issues related to the AWS transition are not serious enough to justify an outage report or a note that ci.jenkins.io is down.
