### PR TITLE
Open issue for unresponsicve `infra.ci.jenkins.io`

### DIFF
--- a/content/issues/2025-07-29-infra.ci-down.md
+++ b/content/issues/2025-07-29-infra.ci-down.md
@@ -1,0 +1,20 @@
+---
+title: infra.ci.jenkins.io down
+date: 2025-07-28T8:00:00-00:00
+resolved: false
+resolvedWhen: 2025-07-28T8:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - infra.ci.jenkins.io
+section: issue
+---
+[Final message]
+
+
+[Initial message]
+
+The infra.ci.jenkins.io is down with Warning  FailedAttachVolume  96s (x44 over 160m)  attachdetach-controller  AttachVolume.Attach failed for volume "jenkins-infra-data" : timed out waiting for external-attacher of disk.csi.azure.com CSI driver to attach volume /subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/infra-ci-jenkins-io-controller/providers/Microsoft.Compute/disks/jenkins-infra-data
+
+
+<!-- https://github.com/jenkins-infra/helpdesk/issues/3823#issuecomment-2036372624 -->


### PR DESCRIPTION
`infra.ci.jenkins.io` is currently down with 

```
Warning  FailedAttachVolume  96s (x44 over 160m)  attachdetach-controller  AttachVolume.Attach failed for volume "jenkins-infra-data" : timed out waiting for external-attacher of disk.csi.azure.com CSI driver to attach volume /subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/infra-ci-jenkins-io-controller/providers/Microsoft.Compute/disks/jenkins-infra-data
```