### PR TITLE
open jira expired certificate outage

### DIFF
--- a/content/issues/2025-08-02-jira-tls-expired.md
+++ b/content/issues/2025-08-02-jira-tls-expired.md
@@ -1,0 +1,17 @@
+---
+title: Expired TLS certificate on issues.jenkins.io
+date: 2025-08-02T20:00:00-00:00
+resolved: false
+resolvedWhen: 2025-08-03T20:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - issues.jenkins.io
+section: issue
+---
+
+The JIRA service at issues.jenkins.io (issues.jenkins-ci.org) is unavailable due to an expired TLS certificate.
+
+The Jenkins infrastructure is working with the Linux Foundation team (whom manage the JIRA service) to solve this issue.
+
+More details in https://github.com/jenkins-infra/helpdesk/issues/4757.


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4757