### PR TITLE
Open issue for Security Advisory on 2026-05-27

### DIFF
--- a/content/issues/2026-05-27-ci-maintenance-sec-advisory.md
+++ b/content/issues/2026-05-27-ci-maintenance-sec-advisory.md
@@ -1,0 +1,22 @@
+---
+title: Maintenance on ci.jenkins.io (Security Advisory)
+date: 2026-05-27T11:30:00-00:00
+resolved: false
+resolvedWhen: 2026-05-27T13:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+<!--
+[Final Message]
+The ci.jenkins.io controller is running with latest plugins.
+
+[Initial message]
+-->
+
+Wednesday May 27 2026, the `ci.jenkins.io` controller will be put offline and updated as part of a security advisory at 11:30 UTC.
+
+More details in <https://groups.google.com/g/jenkinsci-advisories/c/87rdJzH1F1E>.


### PR DESCRIPTION
Also added a system message in ci.jenkins.io:

<img width="1621" height="679" alt="Capture d’écran 2026-05-27 à 12 05 48" src="https://github.com/user-attachments/assets/6d444de6-d8cf-4e41-bf41-903af409de46" />
