### PR TITLE
chore(GHA/check-links) replace deprecated action

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: check-links
-        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+        uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1
         with:
           check-modified-files-only: yes
           base-branch: main


### PR DESCRIPTION
https://github.com/gaurav-nelson/github-action-markdown-link-check has been archived in April 2026.

It suggests to use https://github.com/tcort/github-action-markdown-link-check as replacement