### PR TITLE
Upgrade s390x agent from Ubuntu 24.04 to 26.04

### DIFF
--- a/content/issues/2026-08-03-s390x-agent-upgrade.md
+++ b/content/issues/2026-08-03-s390x-agent-upgrade.md
@@ -1,0 +1,13 @@
+---
+title: s390x agent down on ci.jenkins.io
+date: 2026-08-03T17:50:00-00:00
+resolved: false
+resolvedWhen: 2026-08-03T19:00:00-00:00
+# Possible severity levels: down, disrupted, notice
+severity: down
+affected:
+  - ci.jenkins.io
+section: issue
+---
+
+The IBM System 390 agent connected to ci.jenkins.io will be down for an operating system upgrade during a maintenance window Monday 3 Aug 2026 from 18:00 to 19:00 UTC.


### PR DESCRIPTION
## Upgrade s390x agent from Ubuntu 24.04 to 26.04

Part of the Ubuntu 26.04 upgrade campaign

Help desk ticket:

* https://github.com/jenkins-infra/helpdesk/issues/5246
